### PR TITLE
added cancelPerpOrderByClientId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Associated token account is created before withdrawal if such account does not exist
 - Old implementations of deposit / withdrawals are repurposed as depositRaw/ withdrawRaw in case users want to deposit/withdraw to/from a specific account
 - Add a limit arg to placePerpOrder used when compute limit is reached
+- ClientId as an input to placePerpOrder to tag specific orders with a unique id, that can be used to specifically cancel
+- New instruction cancelPerpOrderByClientId that cancels using the pre-assigned unique client id
 
 ### Changed 
 - Swap is now simplified. Takes in big units (like SOL and BTC) instead of smol units (like satoshis and lamports). Accepts a slippage parameter. 

--- a/src/types/zo.ts
+++ b/src/types/zo.ts
@@ -401,6 +401,10 @@ export type Zo = {
         {
           "name": "limit",
           "type": "u16"
+        },
+        {
+          "name": "clientId",
+          "type": "u64"
         }
       ]
     },
@@ -471,6 +475,72 @@ export type Zo = {
         {
           "name": "isLong",
           "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "cancelPerpOrderByClientId",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "cache",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "margin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "control",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "openOrders",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "dexMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "marketBids",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "marketAsks",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "eventQ",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "dexProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "clientId",
+          "type": "u64"
         }
       ]
     },
@@ -2463,6 +2533,10 @@ export const IDL: Zo = {
         {
           "name": "limit",
           "type": "u16"
+        },
+        {
+          "name": "clientId",
+          "type": "u64"
         }
       ]
     },
@@ -2533,6 +2607,72 @@ export const IDL: Zo = {
         {
           "name": "isLong",
           "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "cancelPerpOrderByClientId",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "cache",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "margin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "control",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "openOrders",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "dexMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "marketBids",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "marketAsks",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "eventQ",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "dexProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "clientId",
+          "type": "u64"
         }
       ]
     },


### PR DESCRIPTION
- Added clientId as an input to placePerpOrder to tag specific orders with a unique id, that can be used to specifically cancel
- Added new instruction cancelPerpOrderByClientId that cancels using the pre-assigned unique client id