### PR TITLE
Fixing npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   "dependencies": {
     "@project-serum/anchor": "^0.19.1-beta.1",
     "@solana/spl-token": "^0.1.8",
-    "@solana/web3.js": "^1.31.0",
     "@zero_one/lite-serum": "^0.1.1",
     "bn.js": "^5.2.0",
     "buffer-layout": "^1.2.2",
     "decimal.js": "^10.3.1"
+  },
+  "peerDependencies": {
+    "@solana/web3.js": "^1.31.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.1",

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,7 +1,7 @@
-import { Coder, Idl } from "@project-serum/anchor";
+import { Coder, Idl, Event } from "@project-serum/anchor";
 
 // t is a base64 encoded string
-export function decode(t: string, idl: Idl) {
+export function decode(t: string, idl: Idl): Event | null {
   const coder = new Coder(idl);
   const event = coder.events.decode(t);
   return event;


### PR DESCRIPTION
Getting the following build errors:

1.
```
> @zero_one/client@0.2.4 build
> tsc && tsc -p tsconfig.cjs.json

../../@solana/web3.js/lib/index.d.ts:2:1 - error TS6200: Definitions of the following identifiers conflict with those in another file: Struct, Enum, SOLANA_SCHEMA, ...

2 declare module '@solana/web3.js' {
  ~~~~~~~

  node_modules/@solana/web3.js/lib/index.d.ts:2:1
    2 declare module '@solana/web3.js' {
      ~~~~~~~
    Conflicts are in this file.

node_modules/@solana/web3.js/lib/index.d.ts:2:1 - error TS6200: Definitions of the following identifiers conflict with those in another file: Struct, Enum, SOLANA_SCHEMA, ...
2 declare module '@solana/web3.js' {
  ~~~~~~~

  ../../@solana/web3.js/lib/index.d.ts:2:1
    2 declare module '@solana/web3.js' {
      ~~~~~~~
    Conflicts are in this file.


Found 2 errors.
```

2.
```
src/utils/events.ts:4:17 - error TS2742: The inferred type of 'decode' cannot be named without a reference to '@zero_one/client/node_modules/@project-serum/anchor/dist/cjs/idl'. This is likely not portable. A type annotation is necessary.

4 export function decode(t: string, idl: Idl) {
                  ~~~~~~


Found 1 error.
```