### PR TITLE
Funding Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero_one/client",
-  "version": "0.8.6",
+  "version": "0.8.7.beta.2",
   "license": "Apache-2.0",
   "description": "TypeScript Client API",
   "main": "dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero_one/client",
-  "version": "0.8.7.beta.2",
+  "version": "0.8.7-beta.9",
   "license": "Apache-2.0",
   "description": "TypeScript Client API",
   "main": "dist/cjs/index.js",

--- a/src/accounts/Cache.ts
+++ b/src/accounts/Cache.ts
@@ -106,10 +106,14 @@ export default class Cache extends BaseAccount<Schema> {
           ...c,
           price: Num.fromWI80F48(c.price, decimals),
           twap: {
-            cumulAvg: Num.fromWI80F48(c.twap.cumulAvg, decimals),
+            cumulAvg: Num.fromWI80F48(c.twap.cumulAvg, 0),
+            // deprecated
             open: Num.fromWI80F48(c.twap.open, decimals),
+            // deprecated
             high: Num.fromWI80F48(c.twap.high, decimals),
+            // deprecated
             low: Num.fromWI80F48(c.twap.low, decimals),
+            // deprecated
             close: Num.fromWI80F48(c.twap.close, decimals),
             lastSampleStartTime: new Date(
               c.twap.lastSampleStartTime.toNumber() * 1000,

--- a/src/accounts/State.ts
+++ b/src/accounts/State.ts
@@ -12,7 +12,12 @@ import {
   ZO_DEX_DEVNET_PROGRAM_ID,
   ZO_DEX_MAINNET_PROGRAM_ID,
 } from "../config";
-import { AssetInfo, MarketInfo, MarketType } from "../types/dataTypes";
+import {
+  AssetInfo,
+  FundingInfo,
+  MarketInfo,
+  MarketType,
+} from "../types/dataTypes";
 import Decimal from "decimal.js";
 import _ from "lodash";
 import Num from "../Num";
@@ -546,5 +551,30 @@ export default class State extends BaseAccount<Schema> {
       index++;
     }
     this.markets = markets;
+  }
+
+  /**
+   * Gets the funding info object for a given market.
+   * Funding will be undefined in the first minute of the hour.
+   * Make sure to handle that case!
+   */
+  getFundingInfo(symbol: string): FundingInfo {
+    const marketIndex = this.getMarketIndexBySymbol(symbol);
+    const lastSampleStartTime =
+      this.cache.data.marks[marketIndex]!.twap.lastSampleStartTime;
+    const cumulAvg = this.cache.data.marks[marketIndex]!.twap.cumulAvg.decimal;
+    const hasData = cumulAvg.abs().gt(0);
+    return {
+      hourly: hasData
+        ? cumulAvg.div(lastSampleStartTime.getMinutes() * 24)
+        : undefined,
+      daily: hasData
+        ? cumulAvg.div(lastSampleStartTime.getMinutes())
+        : undefined,
+      apr: hasData
+        ? cumulAvg.div(lastSampleStartTime.getMinutes()).times(100).times(365)
+        : undefined,
+      lastSampleUpdate: lastSampleStartTime,
+    };
   }
 }

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -3,6 +3,20 @@ import Decimal from "decimal.js"
 import { PublicKey } from "@solana/web3.js"
 import BN from "bn.js"
 
+/**
+ * Funding will be undefined in the first minute of the hour.
+ * Make sure to handle that case!
+ * @hourly - TWAP of (mark - index) / index / 24
+ * @daily - TWAP of (mark - index) / index
+ * @apr - daily funding * 365 * 100 (the result is given in percent)
+ */
+export interface FundingInfo {
+  hourly: Decimal | undefined,
+  daily: Decimal | undefined,
+  apr: Decimal | undefined,
+  lastSampleUpdate: Date,
+}
+
 export enum MarketType {
   Perp,
   EverCall,

--- a/src/zoDex/zoMarket.ts
+++ b/src/zoDex/zoMarket.ts
@@ -18,7 +18,7 @@ import {
 } from "@solana/web3.js";
 import { decodeEventQueue, decodeRequestQueue } from "./queue";
 import { Buffer } from "buffer";
-import { throwIfNull } from "../utils";
+import { FundingInfo, MarketInfo, throwIfNull } from "../utils";
 import { TransactionId } from "../types";
 import {
   WRAPPED_SOL_MINT,


### PR DESCRIPTION
- Add `getFundingInfo` to `State`, which returns `FundingInfo` object
- TwapInfo object's cumulAvg is reworked. TwapInfo's ohlc fields are now deprecated.